### PR TITLE
Fixes prerelease NuGet file name

### DIFF
--- a/lib/utils/add-assets-info.js
+++ b/lib/utils/add-assets-info.js
@@ -63,7 +63,6 @@ function addAssetsInfo(build, options) {
 }
 
 // https://github.com/electron-userland/electron-builder/issues/651
-//
 function convertWindowsVersion(version) {
   const parts = version.split('-');
   const mainVersion = parts.shift();

--- a/lib/utils/add-assets-info.js
+++ b/lib/utils/add-assets-info.js
@@ -62,6 +62,19 @@ function addAssetsInfo(build, options) {
   }, build);
 }
 
+// https://github.com/electron-userland/electron-builder/issues/651
+//
+function convertWindowsVersion(version) {
+  const parts = version.split('-');
+  const mainVersion = parts.shift();
+
+  if (parts.length > 0) {
+    return [mainVersion, parts.join('-').replace(/\./g, '')].join('-');
+  }
+
+  return mainVersion;
+}
+
 function resolveAssetPath(assetsPath, assetMask, options, exception = true) {
   if (!assetMask) return null;
 
@@ -73,11 +86,15 @@ function resolveAssetPath(assetsPath, assetMask, options, exception = true) {
     return filePath || resolveAssetPath(assetsPath, assetMask[0], options);
   }
 
+  const version = /\.nupkg$/.test(assetMask)
+    ? convertWindowsVersion(options.version)
+    : options.version;
+
   const json = options.packageJson;
   const fileName = assetMask
     .replace('{name}', json.name)
     .replace('{productName}', json.productName || json.name)
-    .replace('{version}', options.version);
+    .replace('{version}', version);
   const filePath = path.join(assetsPath, fileName);
 
   if (!fs.existsSync(filePath)) {


### PR DESCRIPTION
The prerelease version needs an adjustment when the tag has a dot. This is the current output:

**version**: `1.0.0-beta.1`

```
File /XXXXXX/win/app-1.0.0-beta.1-full.nupkg doesn't exists. You can try to check if:
 - electron-builder successfully made a build
 - electron-builder and electron-simple-publisher are up to date
 - if nothing helps please create a new github issue. Don't forget to include electron-builder version to the bug report.
```

For NuGet the target filename should be `app-1.0.0-beta1-full.nupkg`.

**Related**:
- http://semver.org/#spec-item-9
- electron-userland/electron-builder/issues/651.