### PR TITLE
Removed need to enter s3 credentials

### DIFF
--- a/lib/transport/s3.js
+++ b/lib/transport/s3.js
@@ -19,16 +19,11 @@ class S3Transport extends AbstractTransport {
     super.normalizeOptions(options);
 
     const awsAuth = {
-      accessKeyId: options.accessKeyId,
-      secretAccessKey: options.secretAccessKey,
+      accessKeyId: (options.accessKeyId ? options.accessKeyId : undefined),
+      secretAccessKey: (options.secretAccessKey ? options.secretAccessKey : undefined),
       signatureVersion: 'v4'
     };
     options.aws = Object.assign(awsAuth, options.aws);
-    for (const name of ['accessKeyId', 'secretAccessKey']) {
-      if (!options.aws[name]) {
-        throw new Error(`The transport.${name} option is not set`);
-      }
-    }
 
     if (!options.bucket) {
       options.bucket = this.commandOptions.packageJson.name + '-updates';

--- a/lib/transport/s3.js
+++ b/lib/transport/s3.js
@@ -19,8 +19,8 @@ class S3Transport extends AbstractTransport {
     super.normalizeOptions(options);
 
     const awsAuth = {
-      accessKeyId: (options.accessKeyId ? options.accessKeyId : undefined),
-      secretAccessKey: (options.secretAccessKey ? options.secretAccessKey : undefined),
+      accessKeyId: options.accessKeyId,
+      secretAccessKey: options.secretAccessKey,
       signatureVersion: 'v4'
     };
     options.aws = Object.assign(awsAuth, options.aws);


### PR DESCRIPTION
This allows default behavior of AWS module (pulling user credentials from `~/.aws/credentials`) to override if `accessKeyId` and `secretAccessKey` are undefined. I also remove the error check that would prevent the progress of this module in this case. 

Fixes #19 