### PR TITLE
Added new install path for darwin target

### DIFF
--- a/lib/utils/add-assets-info.js
+++ b/lib/utils/add-assets-info.js
@@ -14,6 +14,7 @@ const ASSETS_DATA = {
     metaFile: null,
     update: [
       '{productName}-{version}-mac.zip',
+      '{productName}-darwin-x64-{version}.zip',
       path.join('mac', '{productName}-{version}-mac.zip')
     ]
   },


### PR DESCRIPTION
This change is required for simple publisher to work on my project. Maybe caused by a recent change in electron forge or electron packager ?