### PR TITLE
add linux-armv7l support

### DIFF
--- a/lib/utils/add-assets-info.js
+++ b/lib/utils/add-assets-info.js
@@ -28,6 +28,11 @@ const ASSETS_DATA = {
     metaFile: null,
     update: '{name}-{version}-x86_64.AppImage'
   },
+  'linux-armv7l': {
+    install: '{name}-{version}-armv7l.AppImage',
+    metaFile: null,
+    update: '{name}-{version}-armv7l.AppImage'
+  },
   'win32-ia32': {
     install: [
       path.join('squirrel-windows-ia32', '{productName} Setup {version}.exe'),


### PR DESCRIPTION
Finally I PR fix my #38 issue

Thanks

For those who need that feature please note that your linux have to init (or test arch) build like this in electron-simple-updater/main.js:
```js
updater.init({
  checkUpdateOnStart: false,
  autoDownload: false,
  build:"linux-armv7l"//<< here
});
```